### PR TITLE
export package.json path

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
       "types": "./dist/index.d.ts",
       "svelte": "./dist/index.js"
     },
+    "./package.json": "./package.json",
     "./Accordion.svelte": {
       "types": "./dist/accordion/Accordion.svelte.d.ts",
       "svelte": "./dist/accordion/Accordion.svelte"


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->


## 📑 Description

This pull request addresses an error encountered in certain projects. The error message reads:

```
Failed to resolve entry for package "flowbite-svelte". The package may have incorrect main/module/exports specified in its package.json: No known conditions for "." entry in "flowbite-svelte" package
```
![image](https://github.com/kevinbreaker/flowbite-svelte/assets/25128546/d77f3621-5838-46b7-aec5-2b26b301ca7e)


Solution:
This pull request implements a fix by explicitly exporting the package's entry point in the package.json file. This modification ensures that Vite accurately resolves the package's entry and prevents the aforementioned error.


